### PR TITLE
Feature/build error type response

### DIFF
--- a/src/ModelValidationAsyncActionFilter.cs
+++ b/src/ModelValidationAsyncActionFilter.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections;
 using System.Linq;
 using System.Threading.Tasks;
+using FluentValidation.Results;
 
 namespace JSM.FluentValidation.AspNet.AsyncFilter
 {
@@ -125,8 +126,13 @@ namespace JSM.FluentValidation.AspNet.AsyncFilter
 
             var context = new ValidationContext<object>(value);
             var result = await validator.ValidateAsync(context);
-            result.AddToModelState(modelState, string.Empty);
+            var errorCode = GetErrorCodeWithPrefixType(result);
+            
+            result.AddToModelState(modelState, errorCode);
         }
+
+        private string GetErrorCodeWithPrefixType(ValidationResult result) => 
+            result.Errors.LastOrDefault(errorCode => errorCode.ErrorCode.Contains(RuleTypeConst.Prefix))?.ErrorCode;
 
         private IValidator GetValidator(Type targetType)
         {

--- a/src/ModelValidationAsyncActionFilter.cs
+++ b/src/ModelValidationAsyncActionFilter.cs
@@ -126,12 +126,12 @@ namespace JSM.FluentValidation.AspNet.AsyncFilter
 
             var context = new ValidationContext<object>(value);
             var result = await validator.ValidateAsync(context);
-            var errorCode = GetErrorCodeWithPrefixType(result);
+            var errorCode = GetErrorCodeWithPrefixRuleType(result);
             
             result.AddToModelState(modelState, errorCode);
         }
 
-        private string GetErrorCodeWithPrefixType(ValidationResult result) => 
+        private string GetErrorCodeWithPrefixRuleType(ValidationResult result) => 
             result.Errors.LastOrDefault(errorCode => errorCode.ErrorCode.Contains(RuleTypeConst.Prefix))?.ErrorCode;
 
         private IValidator GetValidator(Type targetType)

--- a/src/ModelValidationAsyncActionFilter.cs
+++ b/src/ModelValidationAsyncActionFilter.cs
@@ -131,7 +131,7 @@ namespace JSM.FluentValidation.AspNet.AsyncFilter
             result.AddToModelState(modelState, errorCode);
         }
 
-        private string GetErrorCodeWithPrefixRuleType(ValidationResult result) => 
+        private static string GetErrorCodeWithPrefixRuleType(ValidationResult result) => 
             result.Errors.LastOrDefault(errorCode => errorCode.ErrorCode.Contains(RuleTypeConst.Prefix))?.ErrorCode;
 
         private IValidator GetValidator(Type targetType)

--- a/src/RuleTypeBuilderExtensions.cs
+++ b/src/RuleTypeBuilderExtensions.cs
@@ -1,0 +1,33 @@
+﻿using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
+using System.Linq;
+
+namespace JSM.FluentValidation.AspNet.AsyncFilter
+{
+    /// <summary>
+    /// Extension to override error code with prefix and type.
+    /// </summary>
+    public static class RuleTypeBuilderExtensions
+    {
+
+        /// <summary>
+        /// Overrides the error code associated with this rule with prefix and type
+        /// </summary>
+        /// <param name="rule">The current rule</param>
+        /// <param name="type">The type used to override error code/param>
+        /// <returns></returns>
+        public static IRuleBuilderOptions<T, TProperty> WithRuleType<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, string type)
+        {
+            string propertyName = "";
+
+            var options = rule.Configure(x => propertyName = x.GetDisplayName(null));
+
+            if (!string.IsNullOrEmpty(propertyName))
+                options.WithName(propertyName);
+
+            options.WithErrorCode($"{RuleTypeConst.Prefix}.{type}");
+
+            return options;
+        }
+    }
+}

--- a/src/RuleTypeBuilderExtensions.cs
+++ b/src/RuleTypeBuilderExtensions.cs
@@ -9,12 +9,13 @@ namespace JSM.FluentValidation.AspNet.AsyncFilter
     /// </summary>
     public static class RuleTypeBuilderExtensions
     {
-
         /// <summary>
         /// Overrides the error code associated with this rule with prefix and type
         /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="TProperty"></typeparam>
         /// <param name="rule">The current rule</param>
-        /// <param name="type">The type used to override error code/param>
+        /// <param name="type">The type used to override error code</param>
         /// <returns></returns>
         public static IRuleBuilderOptions<T, TProperty> WithRuleType<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, string type)
         {

--- a/src/RuleTypeConst.cs
+++ b/src/RuleTypeConst.cs
@@ -1,0 +1,13 @@
+﻿namespace JSM.FluentValidation.AspNet.AsyncFilter
+{
+    /// <summary>
+    /// Const used do configure method WithRuleType.
+    /// </summary>
+    public static class RuleTypeConst
+    {
+        /// <summary>
+        /// Prefix used to override property name.
+        /// </summary>
+        public const string Prefix = "_RuleType";
+    }
+}

--- a/tests/ModelValidationAsyncActionFilterWithRuleTypeTests.cs
+++ b/tests/ModelValidationAsyncActionFilterWithRuleTypeTests.cs
@@ -1,0 +1,53 @@
+﻿using FluentAssertions;
+using JSM.FluentValidation.AspNet.AsyncFilter.Tests.Support;
+using JSM.FluentValidation.AspNet.AsyncFilter.Tests.Support.Models;
+using JSM.FluentValidation.AspNet.AsyncFilter.Tests.Support.Startups;
+using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace JSM.FluentValidation.AspNet.AsyncFilter.Tests
+{
+    public class ModelValidationAsyncActionFilterWithRuleTypeTests : WebAppFixture<StartupWithDefaultOptions>
+    {
+        private const string ControllerWithRuleTypeEndpoint = "WithRuleType";
+        private HttpClient Client { get; }
+
+        public ModelValidationAsyncActionFilterWithRuleTypeTests() => Client = CreateClient();
+
+        [Fact(DisplayName = "Should return OK when payload is valid")]
+        public async Task OnActionExecutionAsync_PayloadIsValid_ReturnOk()
+        {
+            // Arrange
+            var payload = new TestPayloadWithRuleType { Text = "Test" };
+
+            // Act
+            var response = await Client.PostAsJsonAsync($"{ControllerWithRuleTypeEndpoint}/test-validator", payload);
+
+            // Assert
+            response.Should().Be200Ok();
+        }
+
+        [Fact(DisplayName = "Should return bad request when payload is invalid")]
+        public async Task OnActionExecutionAsync_PayloadIsInvalid_ReturnBadRequest()
+        {
+            // Arrange
+            var payload = new TestPayloadWithRuleType { Text = "" };
+
+            // Act
+            var response = await Client.PostAsJsonAsync($"{ControllerWithRuleTypeEndpoint}/test-validator", payload);
+
+            // Assert
+            response.Should().Be400BadRequest();
+            var responseDetails = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>();
+            responseDetails.Title.Should().Be("One or more validation errors occurred.");
+            responseDetails.Errors.Should().BeEquivalentTo(new Dictionary<string, string[]>
+            {
+                { $"{RuleTypeConst.Prefix}.SOME_RULE.Text", new[] { "Text can't be null" } }
+            });
+        }
+    }
+}

--- a/tests/Support/Controllers/WithRuleTypeController.cs
+++ b/tests/Support/Controllers/WithRuleTypeController.cs
@@ -1,0 +1,13 @@
+﻿using JSM.FluentValidation.AspNet.AsyncFilter.Tests.Support.Models;
+using Microsoft.AspNetCore.Mvc;
+using System;
+
+namespace JSM.FluentValidation.AspNet.AsyncFilter.Tests.Support.Controllers
+{
+    [ApiController, Route("[controller]")]
+    public class WithRuleTypeController : ControllerBase
+    {
+        [HttpPost("test-validator")]
+        public IActionResult Post([FromBody] TestPayloadWithRuleType request) => Ok();
+    }
+}

--- a/tests/Support/Models/TestPayloadWithRuleType.cs
+++ b/tests/Support/Models/TestPayloadWithRuleType.cs
@@ -1,0 +1,20 @@
+﻿using FluentValidation;
+
+namespace JSM.FluentValidation.AspNet.AsyncFilter.Tests.Support.Models
+{
+    public class TestPayloadWithRuleType
+    {
+        public string Text { get; set; }
+    }
+
+    public class TestPayloadWithRuleTypeValidator : AbstractValidator<TestPayloadWithRuleType>
+    {
+        public TestPayloadWithRuleTypeValidator()
+        {
+            RuleFor(x => x.Text)
+                .NotEmpty()
+                .WithMessage("Text can't be null")
+                .WithRuleType("SOME_RULE");
+        }
+    }
+}


### PR DESCRIPTION
# Summary

Create method _WithRuleType_ in validation, to override property name with Prefix and Type.

**How to use method _WithRuleType_ in validation?**
```
RuleFor(x => x.Text)
                .NotEmpty()
                .WithMessage("Text can't be null")
                .WithRuleType("SOME_RULE");
```

**How property name stay?** 
```
{Prefix}.{RuleType}.{PropertyName}
_RuleType.SOME_RULE.Text
```
**Why use it?**
To identify Rules in InvalidModelStateResponseFactory and customize the HTTP response.
```
public static class MvcBuilderExtensions
{
    private const string PropertyDefault = "msg";

    /// <summary>
    /// Configure the custom bad request response format for all validation errors (model binding and ModelValidationFilter).
    /// </summary>
    /// <param name="builder"></param>
    /// <returns></returns>
    public static IMvcBuilder ConfigureValidationResponseFormat(this IMvcBuilder builder)
    {
        builder.ConfigureApiBehaviorOptions(options =>
        {
            options.InvalidModelStateResponseFactory = context =>
            {
                var response = new ErrorResponse
                {
                    Error = new Dictionary<string, string[]>(),
                    Type = GetRuleType(context)
                };

                foreach (var (key, value) in context.ModelState.Where(x => x.Value.Errors.Any()))
                {
                    var errorMessage = value.Errors.Select(e => e.ErrorMessage).ToArray();
                    var errorKey = key.Contains(RuleTypeConst.Prefix) ? PropertyDefault : key;
                    response.Error.Add(errorKey, errorMessage);
                }

                return new BadRequestObjectResult(response);
            };
        });

        return builder;
    }

    private static string GetRuleType(ActionContext context)
    {
        var type = "ERROR_DEFAULT";

        var errorType = context.ModelState.LastOrDefault(error => error.Key.Contains(RuleTypeConst.Prefix));

        if (!string.IsNullOrEmpty(errorType.Key))
            type = GetRuleType(errorType.Key);

        return type;
    }

    private static string GetRuleType(string key) =>
        key.Split('.')[1];
}
```