### PR TITLE
Feature/build error type response

### DIFF
--- a/src/ApiBehaviorOptionsSetup.cs
+++ b/src/ApiBehaviorOptionsSetup.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+
+namespace JSM.FluentValidation.AspNet.AsyncFilter
+{
+    internal class ApiBehaviorOptionsSetup : IConfigureOptions<ApiBehaviorOptions>
+    {
+        private readonly IConfigureOptions<ApiBehaviorOptions> _options;
+        public ApiBehaviorOptionsSetup(IConfigureOptions<ApiBehaviorOptions> configureOptions)
+        {
+            _options = configureOptions;
+        }
+
+        public void Configure(ApiBehaviorOptions options)
+        {
+            _options.Configure(options);
+            options.InvalidModelStateResponseFactory = context =>
+            {
+                var problemDetailsFactory = context.HttpContext.RequestServices.GetRequiredService<ProblemDetailsFactory>();
+                return ConfigureValidationResponseFormat(problemDetailsFactory, context);
+            };
+        }
+
+        private static IActionResult ConfigureValidationResponseFormat(ProblemDetailsFactory problemDetailsFactory, ActionContext context)
+        {
+            var problemDetails = problemDetailsFactory.CreateValidationProblemDetails(context.HttpContext, context.ModelState);
+            if (problemDetails.Status == (int)HttpStatusCode.BadRequest)
+            {
+                var response = new ErrorResponse
+                {
+                    Error = new Dictionary<string, string[]>(),
+                    Type = context.ModelState.GetLastRuleType()
+                };
+
+                foreach (var (key, value) in context.ModelState.Where(x => x.Value.Errors.Any()))
+                {
+                    var errorKey = key.Contains(RuleTypeConst.Prefix) ? RuleTypeConst.KeyErrorDefault : key;
+                    var errorMessage = value.Errors.Select(e => e.ErrorMessage).ToArray();
+                    response.Error.Add(errorKey, errorMessage);
+                }
+
+                return new BadRequestObjectResult(response);
+            }
+
+            return new ObjectResult(problemDetails)
+            {
+                StatusCode = problemDetails.Status,
+                ContentTypes =
+                {
+                    "application/problem+json",
+                    "application/problem+xml",
+                }
+            };
+        }
+    }
+}

--- a/src/ErrorResponse.cs
+++ b/src/ErrorResponse.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+
+namespace JSM.FluentValidation.AspNet.AsyncFilter
+{
+    /// <summary>
+    /// Class serializable in response error
+    /// </summary>
+    public class ErrorResponse
+    {
+        /// <summary>
+        /// Errors returned in response
+        /// </summary>
+        public Dictionary<string, string[]> Error { get; set; }
+
+        /// <summary>
+        /// Type returned in response
+        /// </summary>
+        public string Type { get; set; }
+    }
+}

--- a/src/ModelValidationAsyncActionFilter.cs
+++ b/src/ModelValidationAsyncActionFilter.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections;
 using System.Linq;
 using System.Threading.Tasks;
+using FluentValidation.Results;
 
 namespace JSM.FluentValidation.AspNet.AsyncFilter
 {
@@ -125,8 +126,13 @@ namespace JSM.FluentValidation.AspNet.AsyncFilter
 
             var context = new ValidationContext<object>(value);
             var result = await validator.ValidateAsync(context);
-            result.AddToModelState(modelState, string.Empty);
+            var errorCode = GetErrorCodeWithPrefixType(result);
+            
+            result.AddToModelState(modelState, errorCode);
         }
+
+        private string GetErrorCodeWithPrefixType(ValidationResult result) => 
+            result.Errors.LastOrDefault(errorCode => errorCode.ErrorCode.Contains(RuleTypeConst.Prefix))?.ErrorCode;
 
         private IValidator GetValidator(Type targetType)
         {

--- a/src/ModelValidationAsyncActionFilter.cs
+++ b/src/ModelValidationAsyncActionFilter.cs
@@ -126,12 +126,12 @@ namespace JSM.FluentValidation.AspNet.AsyncFilter
 
             var context = new ValidationContext<object>(value);
             var result = await validator.ValidateAsync(context);
-            var errorCode = GetErrorCodeWithPrefixType(result);
+            var errorCode = GetErrorCodeWithPrefixRuleType(result);
             
             result.AddToModelState(modelState, errorCode);
         }
 
-        private string GetErrorCodeWithPrefixType(ValidationResult result) => 
+        private string GetErrorCodeWithPrefixRuleType(ValidationResult result) => 
             result.Errors.LastOrDefault(errorCode => errorCode.ErrorCode.Contains(RuleTypeConst.Prefix))?.ErrorCode;
 
         private IValidator GetValidator(Type targetType)

--- a/src/ModelValidationAsyncActionFilter.cs
+++ b/src/ModelValidationAsyncActionFilter.cs
@@ -131,7 +131,7 @@ namespace JSM.FluentValidation.AspNet.AsyncFilter
             result.AddToModelState(modelState, errorCode);
         }
 
-        private string GetErrorCodeWithPrefixRuleType(ValidationResult result) => 
+        private static string GetErrorCodeWithPrefixRuleType(ValidationResult result) => 
             result.Errors.LastOrDefault(errorCode => errorCode.ErrorCode.Contains(RuleTypeConst.Prefix))?.ErrorCode;
 
         private IValidator GetValidator(Type targetType)

--- a/src/MvcBuilderExtensions.cs
+++ b/src/MvcBuilderExtensions.cs
@@ -1,5 +1,8 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using System;
+using System.Linq;
 
 namespace JSM.FluentValidation.AspNet.AsyncFilter
 {
@@ -18,7 +21,7 @@ namespace JSM.FluentValidation.AspNet.AsyncFilter
             Action<ModelValidationOptions> optionsAction)
         {
             builder.AddMvcOptions(mvcOptions => { mvcOptions.Filters.Add<ModelValidationAsyncActionFilter>(); });
-
+            builder.Services.AddWrapper<IConfigureOptions<ApiBehaviorOptions>>((serviceProvider, t) => new ApiBehaviorOptionsSetup(t));
             builder.Services.Configure(optionsAction);
 
             return builder;
@@ -33,6 +36,16 @@ namespace JSM.FluentValidation.AspNet.AsyncFilter
         {
             return builder
                 .AddModelValidationAsyncActionFilter(_ => { });
+        }
+
+        private static IServiceCollection AddWrapper<T>(this IServiceCollection services, Func<IServiceProvider, T, T> factory)
+           where T : class
+        {
+            var coreResolver = services.Single(x => x.ServiceType == typeof(T));
+            var coreImplementationType = coreResolver.ImplementationType;
+            services.Add(new ServiceDescriptor(coreImplementationType, coreImplementationType, coreResolver.Lifetime));
+            services.Add(new ServiceDescriptor(typeof(T), serviceProvider => factory(serviceProvider, (T)serviceProvider.GetRequiredService(coreImplementationType)), coreResolver.Lifetime));
+            return services;
         }
     }
 }

--- a/src/RuleTypeBuilderExtensions.cs
+++ b/src/RuleTypeBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using System.Linq;
 
 namespace JSM.FluentValidation.AspNet.AsyncFilter
@@ -10,7 +11,7 @@ namespace JSM.FluentValidation.AspNet.AsyncFilter
     public static class RuleTypeBuilderExtensions
     {
         /// <summary>
-        /// Overrides the error code associated with this rule with prefix and type
+        /// Overrides the error code associated with this type
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <typeparam name="TProperty"></typeparam>
@@ -23,12 +24,32 @@ namespace JSM.FluentValidation.AspNet.AsyncFilter
 
             var options = rule.Configure(x => propertyName = x.GetDisplayName(null));
 
-            if (!string.IsNullOrEmpty(propertyName))
-                options.WithName(propertyName);
-
             options.WithErrorCode($"{RuleTypeConst.Prefix}.{type}");
 
             return options;
         }
+
+        internal static string GetLastRuleType(this ModelStateDictionary modelState) =>
+
+            GetRuleTypeInModalState(modelState) ?? RuleTypeConst.TypeDefault;
+
+        /// <summary>
+        /// Get Rule Type registered in format {Prefix}.{Type}.{Key}
+        /// </summary>
+        /// <param name="modelState"></param>
+        /// <returns></returns>
+        private static string GetRuleTypeInModalState(ModelStateDictionary modelState)
+        {
+            var lastErrorType = modelState.LastOrDefault(error => error.Key.Contains(RuleTypeConst.Prefix));
+            if (string.IsNullOrEmpty(lastErrorType.Key))
+                return null;
+            else
+            {
+                int indexType = 1;
+                var type = lastErrorType.Key.Split('.')[indexType];
+                return type;
+            }
+        }
+            
     }
 }

--- a/src/RuleTypeBuilderExtensions.cs
+++ b/src/RuleTypeBuilderExtensions.cs
@@ -1,0 +1,33 @@
+﻿using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
+using System.Linq;
+
+namespace JSM.FluentValidation.AspNet.AsyncFilter
+{
+    /// <summary>
+    /// Extension to override error code with prefix and type.
+    /// </summary>
+    public static class RuleTypeBuilderExtensions
+    {
+
+        /// <summary>
+        /// Overrides the error code associated with this rule with prefix and type
+        /// </summary>
+        /// <param name="rule">The current rule</param>
+        /// <param name="type">The type used to override error code/param>
+        /// <returns></returns>
+        public static IRuleBuilderOptions<T, TProperty> WithRuleType<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, string type)
+        {
+            string propertyName = "";
+
+            var options = rule.Configure(x => propertyName = x.GetDisplayName(null));
+
+            if (!string.IsNullOrEmpty(propertyName))
+                options.WithName(propertyName);
+
+            options.WithErrorCode($"{RuleTypeConst.Prefix}.{type}");
+
+            return options;
+        }
+    }
+}

--- a/src/RuleTypeBuilderExtensions.cs
+++ b/src/RuleTypeBuilderExtensions.cs
@@ -9,12 +9,13 @@ namespace JSM.FluentValidation.AspNet.AsyncFilter
     /// </summary>
     public static class RuleTypeBuilderExtensions
     {
-
         /// <summary>
         /// Overrides the error code associated with this rule with prefix and type
         /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="TProperty"></typeparam>
         /// <param name="rule">The current rule</param>
-        /// <param name="type">The type used to override error code/param>
+        /// <param name="type">The type used to override error code</param>
         /// <returns></returns>
         public static IRuleBuilderOptions<T, TProperty> WithRuleType<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, string type)
         {

--- a/src/RuleTypeConst.cs
+++ b/src/RuleTypeConst.cs
@@ -1,0 +1,13 @@
+﻿namespace JSM.FluentValidation.AspNet.AsyncFilter
+{
+    /// <summary>
+    /// Const used do configure method WithRuleType.
+    /// </summary>
+    public static class RuleTypeConst
+    {
+        /// <summary>
+        /// Prefix used to override property name.
+        /// </summary>
+        public const string Prefix = "_RuleType";
+    }
+}

--- a/src/RuleTypeConst.cs
+++ b/src/RuleTypeConst.cs
@@ -9,5 +9,16 @@
         /// Prefix used to override property name.
         /// </summary>
         public const string Prefix = "_RuleType";
+        
+        /// <summary>
+        /// Type default used in response bad request
+        /// </summary>
+        public const string TypeDefault = "VALIDATION_ERRORS";
+
+        /// <summary>
+        /// Key error default
+        /// </summary>
+        public const string KeyErrorDefault = "msg";
+
     }
 }

--- a/tests/ModelValidationAsyncActionFilterTests.cs
+++ b/tests/ModelValidationAsyncActionFilterTests.cs
@@ -41,16 +41,15 @@ namespace JSM.FluentValidation.AspNet.AsyncFilter.Tests
         public async Task OnActionExecutionAsync_GetEndpointWithInvalidPayload_ReturnBadRequest(string controller)
         {
             // Arrange
-            var payload = new TestPayload { Text = "" };
 
             // Act
             var response = await Client.GetAsync($"{controller}/test-validator?text=");
 
             // Assert
             response.Should().Be400BadRequest();
-            var responseDetails = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>();
-            responseDetails.Title.Should().Be("One or more validation errors occurred.");
-            responseDetails.Errors.Should().BeEquivalentTo(new Dictionary<string, string[]>
+            var responseDetails = await response.Content.ReadFromJsonAsync<ErrorResponse>();
+            responseDetails.Type.Should().Be(RuleTypeConst.TypeDefault);
+            responseDetails.Error.Should().BeEquivalentTo(new Dictionary<string, string[]>
             {
                 { "Text", new[] { "Text can't be null" } }
             });
@@ -69,9 +68,9 @@ namespace JSM.FluentValidation.AspNet.AsyncFilter.Tests
 
             // Assert
             response.Should().Be400BadRequest();
-            var responseDetails = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>();
-            responseDetails.Title.Should().Be("One or more validation errors occurred.");
-            responseDetails.Errors.Should().BeEquivalentTo(new Dictionary<string, string[]>
+            var responseDetails = await response.Content.ReadFromJsonAsync<ErrorResponse>();
+            responseDetails.Type.Should().Be(RuleTypeConst.TypeDefault);
+            responseDetails.Error.Should().BeEquivalentTo(new Dictionary<string, string[]>
             {
                 { "Text", new[] { "Text can't be null" } }
             });
@@ -94,9 +93,9 @@ namespace JSM.FluentValidation.AspNet.AsyncFilter.Tests
 
             // Assert
             response.Should().Be400BadRequest();
-            var responseDetails = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>();
-            responseDetails.Title.Should().Be("One or more validation errors occurred.");
-            responseDetails.Errors.Should().BeEquivalentTo(new Dictionary<string, string[]>
+            var responseDetails = await response.Content.ReadFromJsonAsync<ErrorResponse>();
+            responseDetails.Type.Should().Be(RuleTypeConst.TypeDefault);
+            responseDetails.Error.Should().BeEquivalentTo(new Dictionary<string, string[]>
             {
                 { "Text", new[] { "Text can't be null", "Text can't be null" } }
             });
@@ -141,9 +140,9 @@ namespace JSM.FluentValidation.AspNet.AsyncFilter.Tests
 
             // Assert
             response.Should().Be400BadRequest();
-            var responseDetails = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>();
-            responseDetails.Title.Should().Be("One or more validation errors occurred.");
-            responseDetails.Errors.Should().BeEquivalentTo(new Dictionary<string, string[]>
+            var responseDetails = await response.Content.ReadFromJsonAsync<ErrorResponse>();
+            responseDetails.Type.Should().Be(RuleTypeConst.TypeDefault);
+            responseDetails.Error.Should().BeEquivalentTo(new Dictionary<string, string[]>
             {
                 { "Count", new[] { "Should be less than 3!" } }
             });
@@ -167,9 +166,9 @@ namespace JSM.FluentValidation.AspNet.AsyncFilter.Tests
 
             // Assert
             response.Should().Be400BadRequest();
-            var responseDetails = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>();
-            responseDetails.Title.Should().Be("One or more validation errors occurred.");
-            responseDetails.Errors.Should().BeEquivalentTo(new Dictionary<string, string[]>
+            var responseDetails = await response.Content.ReadFromJsonAsync<ErrorResponse>();
+            responseDetails.Type.Should().Be(RuleTypeConst.TypeDefault);
+            responseDetails.Error.Should().BeEquivalentTo(new Dictionary<string, string[]>
             {
                 { "Count", new[] { "Should be less than 3!" } }
             });

--- a/tests/ModelValidationAsyncActionFilterWithRuleTypeTests.cs
+++ b/tests/ModelValidationAsyncActionFilterWithRuleTypeTests.cs
@@ -42,11 +42,11 @@ namespace JSM.FluentValidation.AspNet.AsyncFilter.Tests
 
             // Assert
             response.Should().Be400BadRequest();
-            var responseDetails = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>();
-            responseDetails.Title.Should().Be("One or more validation errors occurred.");
-            responseDetails.Errors.Should().BeEquivalentTo(new Dictionary<string, string[]>
+            var responseDetails = await response.Content.ReadFromJsonAsync<ErrorResponse>();
+            responseDetails.Type.Should().Be("SOME_RULE");
+            responseDetails.Error.Should().BeEquivalentTo(new Dictionary<string, string[]>
             {
-                { $"{RuleTypeConst.Prefix}.SOME_RULE.Text", new[] { "Text can't be null" } }
+                { RuleTypeConst.KeyErrorDefault , new[] { "Text can't be null" } }
             });
         }
     }

--- a/tests/ModelValidationAsyncActionFilterWithRuleTypeTests.cs
+++ b/tests/ModelValidationAsyncActionFilterWithRuleTypeTests.cs
@@ -1,0 +1,53 @@
+﻿using FluentAssertions;
+using JSM.FluentValidation.AspNet.AsyncFilter.Tests.Support;
+using JSM.FluentValidation.AspNet.AsyncFilter.Tests.Support.Models;
+using JSM.FluentValidation.AspNet.AsyncFilter.Tests.Support.Startups;
+using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace JSM.FluentValidation.AspNet.AsyncFilter.Tests
+{
+    public class ModelValidationAsyncActionFilterWithRuleTypeTests : WebAppFixture<StartupWithDefaultOptions>
+    {
+        private const string ControllerWithRuleTypeEndpoint = "WithRuleType";
+        private HttpClient Client { get; }
+
+        public ModelValidationAsyncActionFilterWithRuleTypeTests() => Client = CreateClient();
+
+        [Fact(DisplayName = "Should return OK when payload is valid")]
+        public async Task OnActionExecutionAsync_PayloadIsValid_ReturnOk()
+        {
+            // Arrange
+            var payload = new TestPayloadWithRuleType { Text = "Test" };
+
+            // Act
+            var response = await Client.PostAsJsonAsync($"{ControllerWithRuleTypeEndpoint}/test-validator", payload);
+
+            // Assert
+            response.Should().Be200Ok();
+        }
+
+        [Fact(DisplayName = "Should return bad request when payload is invalid")]
+        public async Task OnActionExecutionAsync_PayloadIsInvalid_ReturnBadRequest()
+        {
+            // Arrange
+            var payload = new TestPayloadWithRuleType { Text = "" };
+
+            // Act
+            var response = await Client.PostAsJsonAsync($"{ControllerWithRuleTypeEndpoint}/test-validator", payload);
+
+            // Assert
+            response.Should().Be400BadRequest();
+            var responseDetails = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>();
+            responseDetails.Title.Should().Be("One or more validation errors occurred.");
+            responseDetails.Errors.Should().BeEquivalentTo(new Dictionary<string, string[]>
+            {
+                { $"{RuleTypeConst.Prefix}.SOME_RULE.Text", new[] { "Text can't be null" } }
+            });
+        }
+    }
+}

--- a/tests/Support/Controllers/WithRuleTypeController.cs
+++ b/tests/Support/Controllers/WithRuleTypeController.cs
@@ -1,0 +1,13 @@
+﻿using JSM.FluentValidation.AspNet.AsyncFilter.Tests.Support.Models;
+using Microsoft.AspNetCore.Mvc;
+using System;
+
+namespace JSM.FluentValidation.AspNet.AsyncFilter.Tests.Support.Controllers
+{
+    [ApiController, Route("[controller]")]
+    public class WithRuleTypeController : ControllerBase
+    {
+        [HttpPost("test-validator")]
+        public IActionResult Post([FromBody] TestPayloadWithRuleType request) => Ok();
+    }
+}

--- a/tests/Support/Models/TestPayloadWithRuleType.cs
+++ b/tests/Support/Models/TestPayloadWithRuleType.cs
@@ -1,0 +1,20 @@
+﻿using FluentValidation;
+
+namespace JSM.FluentValidation.AspNet.AsyncFilter.Tests.Support.Models
+{
+    public class TestPayloadWithRuleType
+    {
+        public string Text { get; set; }
+    }
+
+    public class TestPayloadWithRuleTypeValidator : AbstractValidator<TestPayloadWithRuleType>
+    {
+        public TestPayloadWithRuleTypeValidator()
+        {
+            RuleFor(x => x.Text)
+                .NotEmpty()
+                .WithMessage("Text can't be null")
+                .WithRuleType("SOME_RULE");
+        }
+    }
+}


### PR DESCRIPTION
# Summary

- Create method _WithRuleType_ in validation, to set type property in response.
- Change lib to response validation rules with a specific response format, implementing your owner InvalidModelStateResponseFactory.
- To use this lib, just need to set AddModelValidationAsyncActionFilter in Startup.cs

**How to use method _WithRuleType_ in validation?**
```
RuleFor(x => x.Text)
                .NotEmpty()
                .WithMessage("Text can't be null")
                .WithRuleType("SOME_RULE");
```

**How response stay?** 
```
{
    "error": {
        "Cnpj": [
            "O CNPJ do cliente é obrigatório"
        ]
    },
    "type": "VALIDATION_ERRORS"
}
```
**Why use it?**
To identify Rules in InvalidModelStateResponseFactory and customize the HTTP response.
Just need to set AddModelValidationAsyncActionFilter in the Startup.cs
```
      services.AddControllers()
                .AddModelValidationAsyncActionFilter(options => options.OnlyApiController = true)
```
