### PR TITLE
ci: run sonar only internally

### DIFF
--- a/.github/workflows/evaluate-pr.yml
+++ b/.github/workflows/evaluate-pr.yml
@@ -18,9 +18,17 @@ jobs:
       - name: Install dotnet-sonarscanner
         run: |
           dotnet tool install --global dotnet-sonarscanner
+
       - name: Build the project, run all tests and publish to SonarCloud
+        if: github.event.pull_request.head.repo.full_name == github.repository
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./scripts/start-sonarcloud.sh ${{ secrets.SONAR_TOKEN }} ${{ github.sha }}
+
+      - name: Build the project and run all tests
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          dotnet build
+          ./scripts/start-tests.sh


### PR DESCRIPTION
# Summary

Differentiate the CI for internal and external contributions.
There are two problems:
- [We can't trust external PRs](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/), so secrets will not be accessible to the workflow when triggered by a fork PR;
- Sonar does not work well will forked PR analysis.

This way, for external contributions, only build and tests will be executed.

https://github.com/juntossomosmais/JSM.FluentValidation.AspNet.AsyncFilter/pull/16#issuecomment-1374305262
